### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ After installing, it may suggest to add initialization code to `~/.bashrc`. Do t
 Configure and install the environment used for this project.
 ```bash
 pyenv local 3.7.7
+mkdir pkg
 pip3 install .
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Copy the [example config](https://github.com/j616/metrolinkTimes/blob/master/con
 
 ## Usage
 
-The API will present itself on port on port 5000 by default. If you're installing from source, run metrolinkTimes from the command line in the repo directory. Logs are placed in `/var/log/metrolinkTimes.log` if running locally or are available through `docker logs` in docker.
+The API will present itself on port on port 5000 by default. If you're installing from source, run metrolinkTimes from the command line in the repo directory with ` python3 -m metrolinkTimes`. Logs are placed in `/var/log/metrolinkTimes.log` if running locally or are available through `docker logs` in docker.
 
 ### /
 


### PR DESCRIPTION
Clarify how to launch API. Avoid "FileNotFoundError: [Errno 2] No such file or directory: 'pkg/_version.py'" after "pip install ." with the following package versions:

setuptools 65.5.1
pip 22.3.1
Python 3.8.10